### PR TITLE
FORMIT-12642: Handle "Set Location Only" case for 3D Context Creator plugin

### DIFF
--- a/plugin.html
+++ b/plugin.html
@@ -20,18 +20,28 @@
         FormItInterface.Initialize(async function () {
 
             // on location set, update the UI to capture the new location
+            // and indicate whether 3D context can be generated
+            FormItInterface.SubscribeMessage("FormIt.Message.kSetLocation", async function(msg)
+            {
+                await FormIt3DContextCreator.updateUI();
+            });
+
+            // on satellite image import, update the UI to capture the new location
+            // and indicate whether 3D context can be generated
             FormItInterface.SubscribeMessage("FormIt.Message.kSatelliteImageIsVisible", async function(msg)
             {
                 await FormIt3DContextCreator.updateUI();
             });
 
             // on new sketch, update the UI to capture the new location
+            // and indicate whether 3D context can be generated
             FormItInterface.SubscribeMessage("FormIt.Message.kNewModelRequested", async function(msg)
             {
                 await FormIt3DContextCreator.updateUI();
             });
 
             // on open file, update the UI to capture the new location
+            // and indicate whether 3D context can be generated
             FormItInterface.SubscribeMessage("FormIt.Message.kLoadComplete", async function(msg)
             {
                 await FormIt3DContextCreator.updateUI();


### PR DESCRIPTION
This PR improves the case where the FormIt user has "Set Location Only" instead of importing satellite imagery. 

This case previously would not update the plugin, and the plugin would indicate that no location was set (not true).

Now, the plugin is refreshed when Set Location Only is invoked, and also displays a message that satellite imagery needs to be imported to generate 3D context.

Also included: Some minor styling improvements.